### PR TITLE
Add multi-AI collaboration entry scaffolding

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -1,0 +1,81 @@
+# ROSC Agent Brief
+
+## Project Status
+
+ROSC is a docs-first Rust project for a next-generation OSC routing bus and
+message broker.
+
+The repository is still in the pre-implementation phase. Production Rust crates
+do not exist yet. At this stage, agents should prefer documentation,
+architecture clarification, backlog hygiene, fixtures, CI scaffolding, and
+implementation planning over shipping runtime code.
+
+## Mission
+
+Build a routing core that is:
+
+- fast under sustained real-time pressure
+- deterministic and observable
+- recoverable after overload or restart
+- backward-compatible with existing OSC workflows
+- extensible without bloating the core
+- usable across Windows, macOS, and Linux
+
+## Read Before Action
+
+Read these before making substantial changes:
+
+1. `../README.md`
+2. `../README.ja.md`
+3. `../docs/design/ja/reading-order.md`
+4. `../docs/design/ja/glossary.md`
+5. `../docs/design/ja/implementation-readiness-checklist.md`
+6. `../docs/concepts/ja/github-foundation-and-collaboration-plan.md`
+7. `./project-map.md`
+8. `./working-agreement.md`
+
+## Non-Negotiable Rules
+
+- Preserve backward compatibility with existing OSC 1.0 traffic.
+- Treat advanced behavior as additive overlays, not mandatory changes to raw
+  OSC.
+- Keep observability, recovery, and rollback paths first-class.
+- Prefer docs-first changes when architecture, compatibility, or operator
+  behavior changes.
+- Keep project-level documentation available in both English and Japanese.
+- Do not bypass pull-request review or the repository protection around `main`.
+- Assume future contributors and agents will rely on clear issue context and
+  explicit handoff notes.
+
+## Working Model
+
+1. Start from an issue when practical, or create one if the work introduces a
+   new stream of effort.
+2. Identify whether the task belongs in `docs/concepts/` or `docs/design/`.
+3. Update English and Japanese files as a pair.
+4. If the task changes architecture intent, compatibility meaning, fault
+   handling, recovery semantics, telemetry interpretation, or plugin trust
+   boundaries, update the design docs first or in the same PR.
+5. If the task changes one of the AI entry directories, mirror the change in
+   `.agent/` and `.agents/`, or in `.skill/` and `.skills/`.
+6. Keep changes small, scoped, and easy to review.
+7. Validate links and repository checks after edits.
+8. Hand off using `./handoff-template.md`.
+
+## If Implementation Starts Later
+
+When the repository moves into code implementation:
+
+- align work to the approved design docs and ADRs
+- preserve the compatibility modes and recovery contract
+- use the conformance and benchmark fixture plans as the baseline evidence set
+- do not claim performance wins without reproducible evidence
+- keep Windows, macOS, and Linux in scope from the first build/test pipeline
+
+## Where To Look Next
+
+- For the repository map: `./project-map.md`
+- For workflow and safety rules: `./working-agreement.md`
+- For role-specific execution guides: `../.skill/SKILL.md`
+- For the formal AI collaboration policy:
+  `../docs/concepts/en/ai-collaboration-and-agent-interop-plan.md`

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -1,0 +1,81 @@
+# ROSC Agent Brief
+
+## Project Status
+
+ROSC is a docs-first Rust project for a next-generation OSC routing bus and
+message broker.
+
+The repository is still in the pre-implementation phase. Production Rust crates
+do not exist yet. At this stage, agents should prefer documentation,
+architecture clarification, backlog hygiene, fixtures, CI scaffolding, and
+implementation planning over shipping runtime code.
+
+## Mission
+
+Build a routing core that is:
+
+- fast under sustained real-time pressure
+- deterministic and observable
+- recoverable after overload or restart
+- backward-compatible with existing OSC workflows
+- extensible without bloating the core
+- usable across Windows, macOS, and Linux
+
+## Read Before Action
+
+Read these before making substantial changes:
+
+1. `../README.md`
+2. `../README.ja.md`
+3. `../docs/design/ja/reading-order.md`
+4. `../docs/design/ja/glossary.md`
+5. `../docs/design/ja/implementation-readiness-checklist.md`
+6. `../docs/concepts/ja/github-foundation-and-collaboration-plan.md`
+7. `./project-map.md`
+8. `./working-agreement.md`
+
+## Non-Negotiable Rules
+
+- Preserve backward compatibility with existing OSC 1.0 traffic.
+- Treat advanced behavior as additive overlays, not mandatory changes to raw
+  OSC.
+- Keep observability, recovery, and rollback paths first-class.
+- Prefer docs-first changes when architecture, compatibility, or operator
+  behavior changes.
+- Keep project-level documentation available in both English and Japanese.
+- Do not bypass pull-request review or the repository protection around `main`.
+- Assume future contributors and agents will rely on clear issue context and
+  explicit handoff notes.
+
+## Working Model
+
+1. Start from an issue when practical, or create one if the work introduces a
+   new stream of effort.
+2. Identify whether the task belongs in `docs/concepts/` or `docs/design/`.
+3. Update English and Japanese files as a pair.
+4. If the task changes architecture intent, compatibility meaning, fault
+   handling, recovery semantics, telemetry interpretation, or plugin trust
+   boundaries, update the design docs first or in the same PR.
+5. If the task changes one of the AI entry directories, mirror the change in
+   `.agent/` and `.agents/`, or in `.skill/` and `.skills/`.
+6. Keep changes small, scoped, and easy to review.
+7. Validate links and repository checks after edits.
+8. Hand off using `./handoff-template.md`.
+
+## If Implementation Starts Later
+
+When the repository moves into code implementation:
+
+- align work to the approved design docs and ADRs
+- preserve the compatibility modes and recovery contract
+- use the conformance and benchmark fixture plans as the baseline evidence set
+- do not claim performance wins without reproducible evidence
+- keep Windows, macOS, and Linux in scope from the first build/test pipeline
+
+## Where To Look Next
+
+- For the repository map: `./project-map.md`
+- For workflow and safety rules: `./working-agreement.md`
+- For role-specific execution guides: `../.skill/SKILL.md`
+- For the formal AI collaboration policy:
+  `../docs/concepts/en/ai-collaboration-and-agent-interop-plan.md`

--- a/.agent/README.md
+++ b/.agent/README.md
@@ -1,0 +1,28 @@
+# ROSC Agent Kit
+
+This directory is a compatibility entry point for AI agents that look for
+project guidance under `.agent/`.
+
+The repository also ships a mirrored `.agents/` tree because some tools only
+scan plural directory names. Keep the two trees aligned.
+
+## Files
+
+- `AGENT.md`
+  - primary machine-readable agent brief
+- `AGENTS.md`
+  - compatibility alias for tools that prefer the plural filename
+- `project-map.md`
+  - condensed map of the repository and must-read documents
+- `working-agreement.md`
+  - mandatory workflow, safety boundaries, and quality gates
+- `handoff-template.md`
+  - expected structure for work summaries and baton passes between agents
+
+## Maintenance Rule
+
+- Update `.agent/` and `.agents/` in the same pull request.
+- Keep file names and content mirrored across both trees.
+- When agent instructions change, update the canonical project documents under
+  `docs/` as needed so the short agent entry points do not drift away from the
+  formal design.

--- a/.agent/handoff-template.md
+++ b/.agent/handoff-template.md
@@ -1,0 +1,37 @@
+# ROSC Handoff Template
+
+Use this structure when handing work to another AI or to a human reviewer.
+
+## Summary
+
+- what changed
+- why it changed
+- what remains open
+
+## Files Changed
+
+- list the touched files and why each mattered
+
+## Related Issues And Docs
+
+- issue numbers or backlog areas
+- design docs or concept docs that guided the work
+- ADRs if applicable
+
+## Validation
+
+- link checks
+- repository checks
+- any manual review steps performed
+- anything intentionally not validated
+
+## Risks Or Open Questions
+
+- unresolved assumptions
+- cross-platform concerns
+- compatibility concerns
+- follow-up docs or issues to create
+
+## Recommended Next Step
+
+- one concrete next action that advances the project safely

--- a/.agent/project-map.md
+++ b/.agent/project-map.md
@@ -1,0 +1,80 @@
+# ROSC Project Map
+
+## Core Repository Entry Points
+
+- `../README.md`
+  - top-level project summary and collaboration rules
+- `../README.ja.md`
+  - Japanese project summary
+- `../CONTRIBUTING.md`
+  - contribution workflow and docs-first expectations
+- `../CONTRIBUTING.ja.md`
+  - Japanese contribution workflow
+- `../SECURITY.md`
+  - security reporting policy
+
+## Formal Documentation Families
+
+- `../docs/concepts/en/`
+  - vision, roadmap, delivery plan, GitHub and collaboration policy
+- `../docs/concepts/ja/`
+  - Japanese planning set
+- `../docs/design/en/`
+  - normative technical specs and operational design
+- `../docs/design/ja/`
+  - Japanese technical specs
+
+## Best Starting Documents
+
+- `../docs/design/ja/reading-order.md`
+- `../docs/design/ja/glossary.md`
+- `../docs/design/ja/implementation-readiness-checklist.md`
+- `../docs/concepts/ja/github-foundation-and-collaboration-plan.md`
+- `../docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md`
+
+## Design Topics That Matter Most
+
+- compatibility modes:
+  `../docs/design/ja/compatibility-matrix.md`
+- internal packet and metadata model:
+  `../docs/design/ja/internal-packet-and-metadata-model.md`
+- fault isolation and overload behavior:
+  `../docs/design/ja/fault-model-and-overload-behavior.md`
+- recovery contract:
+  `../docs/design/ja/recovery-model-and-cache-semantics.md`
+- route semantics:
+  `../docs/design/ja/route-configuration-grammar.md`
+- observability and evidence:
+  `../docs/design/ja/metrics-and-telemetry-schema.md`
+  `../docs/design/ja/benchmark-result-interpretation-guide.md`
+
+## Fixture And Evidence Baseline
+
+- conformance fixtures:
+  `../fixtures/conformance/README.md`
+- benchmark fixtures:
+  `../fixtures/benchmarks/README.md`
+- conformance corpus plan:
+  `../docs/design/en/osc-conformance-corpus-plan.md`
+- benchmark reproducibility plan:
+  `../docs/design/en/benchmark-fixture-inventory-and-reproducibility-plan.md`
+
+## AI-Specific Entry Points
+
+- agent brief:
+  `./AGENT.md`
+- working agreement:
+  `./working-agreement.md`
+- handoff template:
+  `./handoff-template.md`
+- skill catalog:
+  `../.skill/SKILL.md`
+
+## Decision Trail
+
+- ADR index:
+  `../docs/design/en/architecture-decision-record-index.md`
+- ADR folder:
+  `../docs/design/adr/en/README.md`
+
+Use the ADR trail when a task changes the meaning of an existing design rule.

--- a/.agent/working-agreement.md
+++ b/.agent/working-agreement.md
@@ -1,0 +1,73 @@
+# ROSC Working Agreement
+
+## Purpose
+
+This file defines how AI agents should work in this repository without creating
+drift, ambiguity, or unsafe shortcuts.
+
+## Before You Start
+
+- identify the related issue, milestone, or roadmap area
+- identify the affected design or concept documents
+- check whether the work changes repository policy, architecture, compatibility,
+  telemetry meaning, recovery behavior, or plugin trust boundaries
+- if yes, update or consult the relevant docs before claiming the task is done
+
+## Documentation Rules
+
+- project-level docs must remain bilingual
+- `docs/concepts/` is for intent, roadmap, governance, and planning
+- `docs/design/` is for normative behavior, interfaces, semantics, and
+  operational rules
+- do not move content between these families casually
+- keep links healthy when renaming or adding files
+
+## AI Entry-Point Rules
+
+- `.agent/` and `.agents/` are compatibility mirrors
+- `.skill/` and `.skills/` are compatibility mirrors
+- if one tree changes, update the matching tree in the same pull request
+- if a short AI-facing instruction changes meaning, update the formal docs
+  under `docs/` when needed
+
+## Safety And Quality Boundaries
+
+- do not weaken OSC backward compatibility without explicit design approval
+- do not make optional security overlays mandatory for raw OSC interoperability
+- do not claim performance improvements without reproducible evidence
+- do not remove observability or rollback paths in the name of speed
+- do not blur the distinction between rehydrate and replay
+- do not bypass PR-based review to land changes on `main`
+
+## Implementation Boundary For Now
+
+The repository is still pre-implementation.
+
+Allowed high-value work now:
+
+- documentation improvements
+- issue and backlog refinement
+- CI scaffolding for docs and repository hygiene
+- fixture inventories and reproducibility notes
+- implementation planning, crate planning, and contract definition
+
+Avoid for now unless explicitly requested:
+
+- production runtime implementation
+- speculative code generation not grounded in the approved docs
+- benchmark claims without a harness and evidence trail
+
+## Change Scope Rule
+
+- prefer the smallest coherent change that moves one topic forward
+- avoid mixing unrelated cleanup into the same branch
+- keep PR summaries concrete, searchable, and linked to issues/docs
+
+## Completion Checklist
+
+- English and Japanese pairs updated
+- mirror directories kept in sync
+- links verified
+- affected docs and issues referenced
+- open questions recorded
+- handoff written with next recommended step

--- a/.agents/AGENT.md
+++ b/.agents/AGENT.md
@@ -1,0 +1,81 @@
+# ROSC Agent Brief
+
+## Project Status
+
+ROSC is a docs-first Rust project for a next-generation OSC routing bus and
+message broker.
+
+The repository is still in the pre-implementation phase. Production Rust crates
+do not exist yet. At this stage, agents should prefer documentation,
+architecture clarification, backlog hygiene, fixtures, CI scaffolding, and
+implementation planning over shipping runtime code.
+
+## Mission
+
+Build a routing core that is:
+
+- fast under sustained real-time pressure
+- deterministic and observable
+- recoverable after overload or restart
+- backward-compatible with existing OSC workflows
+- extensible without bloating the core
+- usable across Windows, macOS, and Linux
+
+## Read Before Action
+
+Read these before making substantial changes:
+
+1. `../README.md`
+2. `../README.ja.md`
+3. `../docs/design/ja/reading-order.md`
+4. `../docs/design/ja/glossary.md`
+5. `../docs/design/ja/implementation-readiness-checklist.md`
+6. `../docs/concepts/ja/github-foundation-and-collaboration-plan.md`
+7. `./project-map.md`
+8. `./working-agreement.md`
+
+## Non-Negotiable Rules
+
+- Preserve backward compatibility with existing OSC 1.0 traffic.
+- Treat advanced behavior as additive overlays, not mandatory changes to raw
+  OSC.
+- Keep observability, recovery, and rollback paths first-class.
+- Prefer docs-first changes when architecture, compatibility, or operator
+  behavior changes.
+- Keep project-level documentation available in both English and Japanese.
+- Do not bypass pull-request review or the repository protection around `main`.
+- Assume future contributors and agents will rely on clear issue context and
+  explicit handoff notes.
+
+## Working Model
+
+1. Start from an issue when practical, or create one if the work introduces a
+   new stream of effort.
+2. Identify whether the task belongs in `docs/concepts/` or `docs/design/`.
+3. Update English and Japanese files as a pair.
+4. If the task changes architecture intent, compatibility meaning, fault
+   handling, recovery semantics, telemetry interpretation, or plugin trust
+   boundaries, update the design docs first or in the same PR.
+5. If the task changes one of the AI entry directories, mirror the change in
+   `.agent/` and `.agents/`, or in `.skill/` and `.skills/`.
+6. Keep changes small, scoped, and easy to review.
+7. Validate links and repository checks after edits.
+8. Hand off using `./handoff-template.md`.
+
+## If Implementation Starts Later
+
+When the repository moves into code implementation:
+
+- align work to the approved design docs and ADRs
+- preserve the compatibility modes and recovery contract
+- use the conformance and benchmark fixture plans as the baseline evidence set
+- do not claim performance wins without reproducible evidence
+- keep Windows, macOS, and Linux in scope from the first build/test pipeline
+
+## Where To Look Next
+
+- For the repository map: `./project-map.md`
+- For workflow and safety rules: `./working-agreement.md`
+- For role-specific execution guides: `../.skill/SKILL.md`
+- For the formal AI collaboration policy:
+  `../docs/concepts/en/ai-collaboration-and-agent-interop-plan.md`

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,81 @@
+# ROSC Agent Brief
+
+## Project Status
+
+ROSC is a docs-first Rust project for a next-generation OSC routing bus and
+message broker.
+
+The repository is still in the pre-implementation phase. Production Rust crates
+do not exist yet. At this stage, agents should prefer documentation,
+architecture clarification, backlog hygiene, fixtures, CI scaffolding, and
+implementation planning over shipping runtime code.
+
+## Mission
+
+Build a routing core that is:
+
+- fast under sustained real-time pressure
+- deterministic and observable
+- recoverable after overload or restart
+- backward-compatible with existing OSC workflows
+- extensible without bloating the core
+- usable across Windows, macOS, and Linux
+
+## Read Before Action
+
+Read these before making substantial changes:
+
+1. `../README.md`
+2. `../README.ja.md`
+3. `../docs/design/ja/reading-order.md`
+4. `../docs/design/ja/glossary.md`
+5. `../docs/design/ja/implementation-readiness-checklist.md`
+6. `../docs/concepts/ja/github-foundation-and-collaboration-plan.md`
+7. `./project-map.md`
+8. `./working-agreement.md`
+
+## Non-Negotiable Rules
+
+- Preserve backward compatibility with existing OSC 1.0 traffic.
+- Treat advanced behavior as additive overlays, not mandatory changes to raw
+  OSC.
+- Keep observability, recovery, and rollback paths first-class.
+- Prefer docs-first changes when architecture, compatibility, or operator
+  behavior changes.
+- Keep project-level documentation available in both English and Japanese.
+- Do not bypass pull-request review or the repository protection around `main`.
+- Assume future contributors and agents will rely on clear issue context and
+  explicit handoff notes.
+
+## Working Model
+
+1. Start from an issue when practical, or create one if the work introduces a
+   new stream of effort.
+2. Identify whether the task belongs in `docs/concepts/` or `docs/design/`.
+3. Update English and Japanese files as a pair.
+4. If the task changes architecture intent, compatibility meaning, fault
+   handling, recovery semantics, telemetry interpretation, or plugin trust
+   boundaries, update the design docs first or in the same PR.
+5. If the task changes one of the AI entry directories, mirror the change in
+   `.agent/` and `.agents/`, or in `.skill/` and `.skills/`.
+6. Keep changes small, scoped, and easy to review.
+7. Validate links and repository checks after edits.
+8. Hand off using `./handoff-template.md`.
+
+## If Implementation Starts Later
+
+When the repository moves into code implementation:
+
+- align work to the approved design docs and ADRs
+- preserve the compatibility modes and recovery contract
+- use the conformance and benchmark fixture plans as the baseline evidence set
+- do not claim performance wins without reproducible evidence
+- keep Windows, macOS, and Linux in scope from the first build/test pipeline
+
+## Where To Look Next
+
+- For the repository map: `./project-map.md`
+- For workflow and safety rules: `./working-agreement.md`
+- For role-specific execution guides: `../.skill/SKILL.md`
+- For the formal AI collaboration policy:
+  `../docs/concepts/en/ai-collaboration-and-agent-interop-plan.md`

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,28 @@
+# ROSC Agent Kit
+
+This directory is a compatibility entry point for AI agents that look for
+project guidance under `.agent/`.
+
+The repository also ships a mirrored `.agents/` tree because some tools only
+scan plural directory names. Keep the two trees aligned.
+
+## Files
+
+- `AGENT.md`
+  - primary machine-readable agent brief
+- `AGENTS.md`
+  - compatibility alias for tools that prefer the plural filename
+- `project-map.md`
+  - condensed map of the repository and must-read documents
+- `working-agreement.md`
+  - mandatory workflow, safety boundaries, and quality gates
+- `handoff-template.md`
+  - expected structure for work summaries and baton passes between agents
+
+## Maintenance Rule
+
+- Update `.agent/` and `.agents/` in the same pull request.
+- Keep file names and content mirrored across both trees.
+- When agent instructions change, update the canonical project documents under
+  `docs/` as needed so the short agent entry points do not drift away from the
+  formal design.

--- a/.agents/handoff-template.md
+++ b/.agents/handoff-template.md
@@ -1,0 +1,37 @@
+# ROSC Handoff Template
+
+Use this structure when handing work to another AI or to a human reviewer.
+
+## Summary
+
+- what changed
+- why it changed
+- what remains open
+
+## Files Changed
+
+- list the touched files and why each mattered
+
+## Related Issues And Docs
+
+- issue numbers or backlog areas
+- design docs or concept docs that guided the work
+- ADRs if applicable
+
+## Validation
+
+- link checks
+- repository checks
+- any manual review steps performed
+- anything intentionally not validated
+
+## Risks Or Open Questions
+
+- unresolved assumptions
+- cross-platform concerns
+- compatibility concerns
+- follow-up docs or issues to create
+
+## Recommended Next Step
+
+- one concrete next action that advances the project safely

--- a/.agents/project-map.md
+++ b/.agents/project-map.md
@@ -1,0 +1,80 @@
+# ROSC Project Map
+
+## Core Repository Entry Points
+
+- `../README.md`
+  - top-level project summary and collaboration rules
+- `../README.ja.md`
+  - Japanese project summary
+- `../CONTRIBUTING.md`
+  - contribution workflow and docs-first expectations
+- `../CONTRIBUTING.ja.md`
+  - Japanese contribution workflow
+- `../SECURITY.md`
+  - security reporting policy
+
+## Formal Documentation Families
+
+- `../docs/concepts/en/`
+  - vision, roadmap, delivery plan, GitHub and collaboration policy
+- `../docs/concepts/ja/`
+  - Japanese planning set
+- `../docs/design/en/`
+  - normative technical specs and operational design
+- `../docs/design/ja/`
+  - Japanese technical specs
+
+## Best Starting Documents
+
+- `../docs/design/ja/reading-order.md`
+- `../docs/design/ja/glossary.md`
+- `../docs/design/ja/implementation-readiness-checklist.md`
+- `../docs/concepts/ja/github-foundation-and-collaboration-plan.md`
+- `../docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md`
+
+## Design Topics That Matter Most
+
+- compatibility modes:
+  `../docs/design/ja/compatibility-matrix.md`
+- internal packet and metadata model:
+  `../docs/design/ja/internal-packet-and-metadata-model.md`
+- fault isolation and overload behavior:
+  `../docs/design/ja/fault-model-and-overload-behavior.md`
+- recovery contract:
+  `../docs/design/ja/recovery-model-and-cache-semantics.md`
+- route semantics:
+  `../docs/design/ja/route-configuration-grammar.md`
+- observability and evidence:
+  `../docs/design/ja/metrics-and-telemetry-schema.md`
+  `../docs/design/ja/benchmark-result-interpretation-guide.md`
+
+## Fixture And Evidence Baseline
+
+- conformance fixtures:
+  `../fixtures/conformance/README.md`
+- benchmark fixtures:
+  `../fixtures/benchmarks/README.md`
+- conformance corpus plan:
+  `../docs/design/en/osc-conformance-corpus-plan.md`
+- benchmark reproducibility plan:
+  `../docs/design/en/benchmark-fixture-inventory-and-reproducibility-plan.md`
+
+## AI-Specific Entry Points
+
+- agent brief:
+  `./AGENT.md`
+- working agreement:
+  `./working-agreement.md`
+- handoff template:
+  `./handoff-template.md`
+- skill catalog:
+  `../.skill/SKILL.md`
+
+## Decision Trail
+
+- ADR index:
+  `../docs/design/en/architecture-decision-record-index.md`
+- ADR folder:
+  `../docs/design/adr/en/README.md`
+
+Use the ADR trail when a task changes the meaning of an existing design rule.

--- a/.agents/working-agreement.md
+++ b/.agents/working-agreement.md
@@ -1,0 +1,73 @@
+# ROSC Working Agreement
+
+## Purpose
+
+This file defines how AI agents should work in this repository without creating
+drift, ambiguity, or unsafe shortcuts.
+
+## Before You Start
+
+- identify the related issue, milestone, or roadmap area
+- identify the affected design or concept documents
+- check whether the work changes repository policy, architecture, compatibility,
+  telemetry meaning, recovery behavior, or plugin trust boundaries
+- if yes, update or consult the relevant docs before claiming the task is done
+
+## Documentation Rules
+
+- project-level docs must remain bilingual
+- `docs/concepts/` is for intent, roadmap, governance, and planning
+- `docs/design/` is for normative behavior, interfaces, semantics, and
+  operational rules
+- do not move content between these families casually
+- keep links healthy when renaming or adding files
+
+## AI Entry-Point Rules
+
+- `.agent/` and `.agents/` are compatibility mirrors
+- `.skill/` and `.skills/` are compatibility mirrors
+- if one tree changes, update the matching tree in the same pull request
+- if a short AI-facing instruction changes meaning, update the formal docs
+  under `docs/` when needed
+
+## Safety And Quality Boundaries
+
+- do not weaken OSC backward compatibility without explicit design approval
+- do not make optional security overlays mandatory for raw OSC interoperability
+- do not claim performance improvements without reproducible evidence
+- do not remove observability or rollback paths in the name of speed
+- do not blur the distinction between rehydrate and replay
+- do not bypass PR-based review to land changes on `main`
+
+## Implementation Boundary For Now
+
+The repository is still pre-implementation.
+
+Allowed high-value work now:
+
+- documentation improvements
+- issue and backlog refinement
+- CI scaffolding for docs and repository hygiene
+- fixture inventories and reproducibility notes
+- implementation planning, crate planning, and contract definition
+
+Avoid for now unless explicitly requested:
+
+- production runtime implementation
+- speculative code generation not grounded in the approved docs
+- benchmark claims without a harness and evidence trail
+
+## Change Scope Rule
+
+- prefer the smallest coherent change that moves one topic forward
+- avoid mixing unrelated cleanup into the same branch
+- keep PR summaries concrete, searchable, and linked to issues/docs
+
+## Completion Checklist
+
+- English and Japanese pairs updated
+- mirror directories kept in sync
+- links verified
+- affected docs and issues referenced
+- open questions recorded
+- handoff written with next recommended step

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -42,6 +42,29 @@ jobs:
               for rel in missing_in_en:
                   errors.append(f"Missing English pair for {base/'ja'/rel}")
 
+          def ensure_mirrored_tree(a: Path, b: Path):
+              a_files = {p.relative_to(a).as_posix() for p in a.rglob("*.md")}
+              b_files = {p.relative_to(b).as_posix() for p in b.rglob("*.md")}
+              missing_in_b = sorted(a_files - b_files)
+              missing_in_a = sorted(b_files - a_files)
+              for rel in missing_in_b:
+                  errors.append(f"Missing mirrored file in {b.relative_to(root)}: {rel}")
+              for rel in missing_in_a:
+                  errors.append(f"Missing mirrored file in {a.relative_to(root)}: {rel}")
+              for rel in sorted(a_files & b_files):
+                  a_text = (a / rel).read_text(encoding="utf-8")
+                  b_text = (b / rel).read_text(encoding="utf-8")
+                  if a_text != b_text:
+                      errors.append(
+                          f"Mirrored files differ: {a.relative_to(root) / rel} vs {b.relative_to(root) / rel}"
+                      )
+
+          def ensure_equal_files(a: Path, b: Path):
+              if a.read_text(encoding="utf-8") != b.read_text(encoding="utf-8"):
+                  errors.append(
+                      f"Files should match exactly: {a.relative_to(root)} vs {b.relative_to(root)}"
+                  )
+
           def check_links(md_path: Path):
               text = md_path.read_text(encoding="utf-8")
               for match in re.finditer(r"\[[^\]]+\]\(([^)]+)\)", text):
@@ -65,6 +88,14 @@ jobs:
               root / "CODEOWNERS",
               root / "docs" / "README.md",
               root / "docs" / "README.ja.md",
+              root / ".agent" / "AGENT.md",
+              root / ".agent" / "AGENTS.md",
+              root / ".agents" / "AGENT.md",
+              root / ".agents" / "AGENTS.md",
+              root / ".skill" / "SKILL.md",
+              root / ".skill" / "SKILLS.md",
+              root / ".skills" / "SKILL.md",
+              root / ".skills" / "SKILLS.md",
           ]
           for req in required_files:
               if not req.exists():
@@ -72,6 +103,12 @@ jobs:
 
           ensure_pair_tree(root / "docs" / "concepts")
           ensure_pair_tree(root / "docs" / "design")
+          ensure_mirrored_tree(root / ".agent", root / ".agents")
+          ensure_mirrored_tree(root / ".skill", root / ".skills")
+          ensure_equal_files(root / ".agent" / "AGENT.md", root / ".agent" / "AGENTS.md")
+          ensure_equal_files(root / ".agents" / "AGENT.md", root / ".agents" / "AGENTS.md")
+          ensure_equal_files(root / ".skill" / "SKILL.md", root / ".skill" / "SKILLS.md")
+          ensure_equal_files(root / ".skills" / "SKILL.md", root / ".skills" / "SKILLS.md")
 
           for md in root.rglob("*.md"):
               check_links(md)

--- a/.github/workflows/repo-sanity-matrix.yml
+++ b/.github/workflows/repo-sanity-matrix.yml
@@ -43,10 +43,20 @@ jobs:
               "CONTRIBUTING.ja.md",
               "SECURITY.md",
               "SECURITY.ja.md",
+              ".agent/AGENT.md",
+              ".agent/AGENTS.md",
+              ".agents/AGENT.md",
+              ".agents/AGENTS.md",
+              ".skill/SKILL.md",
+              ".skill/SKILLS.md",
+              ".skills/SKILL.md",
+              ".skills/SKILLS.md",
               "docs/concepts/en/license-and-contributor-policy.md",
               "docs/concepts/ja/license-and-contributor-policy.md",
               "docs/concepts/en/ci-expansion-and-required-check-roadmap.md",
               "docs/concepts/ja/ci-expansion-and-required-check-roadmap.md",
+              "docs/concepts/en/ai-collaboration-and-agent-interop-plan.md",
+              "docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md",
               "docs/design/en/rust-workspace-and-crate-boundaries.md",
               "docs/design/ja/rust-workspace-and-crate-boundaries.md",
               "docs/design/en/osc-conformance-corpus-plan.md",
@@ -79,6 +89,33 @@ jobs:
           if len(en_adrs) != len(ja_adrs):
               print("ADR trees are not mirrored between English and Japanese.", file=sys.stderr)
               sys.exit(1)
+
+          for left, right in [
+              (root / ".agent", root / ".agents"),
+              (root / ".skill", root / ".skills"),
+          ]:
+              left_files = {p.relative_to(left).as_posix() for p in left.rglob("*.md")}
+              right_files = {p.relative_to(right).as_posix() for p in right.rglob("*.md")}
+              if left_files != right_files:
+                  print(f"Mirrored AI trees differ: {left} vs {right}", file=sys.stderr)
+                  sys.exit(1)
+              for rel in sorted(left_files):
+                  if (left / rel).read_text(encoding="utf-8") != (right / rel).read_text(encoding="utf-8"):
+                      print(
+                          f"Mirrored AI files differ: {(left / rel).relative_to(root)} vs {(right / rel).relative_to(root)}",
+                          file=sys.stderr,
+                      )
+                      sys.exit(1)
+
+          for left, right in [
+              (root / ".agent/AGENT.md", root / ".agent/AGENTS.md"),
+              (root / ".agents/AGENT.md", root / ".agents/AGENTS.md"),
+              (root / ".skill/SKILL.md", root / ".skill/SKILLS.md"),
+              (root / ".skills/SKILL.md", root / ".skills/SKILLS.md"),
+          ]:
+              if left.read_text(encoding="utf-8") != right.read_text(encoding="utf-8"):
+                  print(f"Alias files diverged: {left.relative_to(root)} vs {right.relative_to(root)}", file=sys.stderr)
+                  sys.exit(1)
 
           print("Repository readiness artifacts look good.")
           PY

--- a/.skill/README.md
+++ b/.skill/README.md
@@ -1,0 +1,31 @@
+# ROSC Skill Catalog
+
+This directory is a compatibility entry point for AI assistants that look for
+project-local skills under `.skill/`.
+
+The repository also ships a mirrored `.skills/` tree because some tools only
+scan plural directory names. Keep the two trees aligned.
+
+## Files
+
+- `SKILL.md`
+  - primary machine-readable skill catalog
+- `SKILLS.md`
+  - compatibility alias for tools that prefer the plural filename
+- `docs-maintainer.md`
+  - for bilingual documentation maintenance and index consistency
+- `design-guardian.md`
+  - for normative design changes, ADR alignment, and scope discipline
+- `issue-curator.md`
+  - for backlog shaping, issue quality, milestones, and acceptance criteria
+- `implementation-planner.md`
+  - for pre-code planning, slicing, and execution sequencing
+- `compatibility-reviewer.md`
+  - for compatibility, recovery, operator impact, and evidence-focused review
+
+## Maintenance Rule
+
+- Update `.skill/` and `.skills/` in the same pull request.
+- Keep file names and content mirrored across both trees.
+- If a skill changes the expected workflow, update the formal docs under
+  `docs/` as well.

--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -1,0 +1,74 @@
+# ROSC Skill Catalog
+
+## Purpose
+
+Use these local skills to keep multi-agent work consistent across planning,
+documentation, backlog management, and future implementation preparation.
+
+## Common Constraints
+
+- preserve OSC 1.0 backward compatibility
+- treat advanced capabilities as additive overlays
+- keep English and Japanese project docs paired
+- keep `.agent/` mirrored with `.agents/`
+- keep `.skill/` mirrored with `.skills/`
+- prefer docs-first changes when semantics or governance change
+- do not claim performance without evidence
+- do not skip issue context, design references, or handoff notes
+
+## Available Skills
+
+### `docs-maintainer.md`
+
+Use when the task is mainly about:
+
+- writing or refining documents
+- keeping English and Japanese files aligned
+- updating indexes, reading order, and cross-links
+- adding new repository guidance without changing runtime behavior
+
+### `design-guardian.md`
+
+Use when the task changes or clarifies:
+
+- normative design behavior
+- compatibility semantics
+- routing, recovery, telemetry, plugin, or security boundaries
+- ADR relationships and design-governance expectations
+
+### `issue-curator.md`
+
+Use when the task is about:
+
+- creating or refining issues
+- ensuring issues are actionable for future contributors or agents
+- aligning backlog items to phases, milestones, risks, and documents
+
+### `implementation-planner.md`
+
+Use when the task is about:
+
+- turning specs into execution slices
+- deciding what should happen before coding
+- defining crate boundaries, acceptance criteria, or validation gates
+- sequencing the first engineering milestones without writing runtime code
+
+### `compatibility-reviewer.md`
+
+Use when the task requires a focused review of:
+
+- OSC compatibility and extension handling
+- operator-visible risk
+- recovery and observability semantics
+- performance claims and evidence quality
+
+## Selection Heuristic
+
+- docs update only: start with `docs-maintainer.md`
+- design meaning changes: start with `design-guardian.md`
+- backlog / GitHub / issue quality: start with `issue-curator.md`
+- roadmap-to-work breakdown: start with `implementation-planner.md`
+- risk review or compatibility check: start with `compatibility-reviewer.md`
+
+If a task spans more than one area, use the most restrictive skill first, then
+bring in the others.

--- a/.skill/SKILLS.md
+++ b/.skill/SKILLS.md
@@ -1,0 +1,74 @@
+# ROSC Skill Catalog
+
+## Purpose
+
+Use these local skills to keep multi-agent work consistent across planning,
+documentation, backlog management, and future implementation preparation.
+
+## Common Constraints
+
+- preserve OSC 1.0 backward compatibility
+- treat advanced capabilities as additive overlays
+- keep English and Japanese project docs paired
+- keep `.agent/` mirrored with `.agents/`
+- keep `.skill/` mirrored with `.skills/`
+- prefer docs-first changes when semantics or governance change
+- do not claim performance without evidence
+- do not skip issue context, design references, or handoff notes
+
+## Available Skills
+
+### `docs-maintainer.md`
+
+Use when the task is mainly about:
+
+- writing or refining documents
+- keeping English and Japanese files aligned
+- updating indexes, reading order, and cross-links
+- adding new repository guidance without changing runtime behavior
+
+### `design-guardian.md`
+
+Use when the task changes or clarifies:
+
+- normative design behavior
+- compatibility semantics
+- routing, recovery, telemetry, plugin, or security boundaries
+- ADR relationships and design-governance expectations
+
+### `issue-curator.md`
+
+Use when the task is about:
+
+- creating or refining issues
+- ensuring issues are actionable for future contributors or agents
+- aligning backlog items to phases, milestones, risks, and documents
+
+### `implementation-planner.md`
+
+Use when the task is about:
+
+- turning specs into execution slices
+- deciding what should happen before coding
+- defining crate boundaries, acceptance criteria, or validation gates
+- sequencing the first engineering milestones without writing runtime code
+
+### `compatibility-reviewer.md`
+
+Use when the task requires a focused review of:
+
+- OSC compatibility and extension handling
+- operator-visible risk
+- recovery and observability semantics
+- performance claims and evidence quality
+
+## Selection Heuristic
+
+- docs update only: start with `docs-maintainer.md`
+- design meaning changes: start with `design-guardian.md`
+- backlog / GitHub / issue quality: start with `issue-curator.md`
+- roadmap-to-work breakdown: start with `implementation-planner.md`
+- risk review or compatibility check: start with `compatibility-reviewer.md`
+
+If a task spans more than one area, use the most restrictive skill first, then
+bring in the others.

--- a/.skill/compatibility-reviewer.md
+++ b/.skill/compatibility-reviewer.md
@@ -1,0 +1,29 @@
+# ROSC Skill: Compatibility Reviewer
+
+## Use This Skill When
+
+- a task could affect OSC interoperability
+- operator-visible behavior or recovery semantics may change
+- a performance claim needs a design-level sanity check
+
+## Goal
+
+Protect backward compatibility, evidence quality, and operational clarity.
+
+## Review Focus
+
+- OSC 1.0 alignment, padding, and big-endian assumptions
+- strict / tolerant / extended mode behavior
+- unknown extension handling
+- recovery cache semantics and late-joiner behavior
+- telemetry meaning and benchmark interpretation
+- rollback and fallback paths
+
+## Output
+
+Leave a concise review that states:
+
+- what looks safe
+- what looks risky
+- what evidence is missing
+- what design doc or issue should be updated next

--- a/.skill/design-guardian.md
+++ b/.skill/design-guardian.md
@@ -1,0 +1,30 @@
+# ROSC Skill: Design Guardian
+
+## Use This Skill When
+
+- a task changes the meaning of a technical rule
+- compatibility semantics, recovery behavior, telemetry semantics, or trust
+  boundaries are being clarified
+- an ADR relationship may need to be referenced or extended
+
+## Goal
+
+Protect the normative design from accidental drift while still improving its
+precision.
+
+## Workflow
+
+1. Find the existing spec or ADR that already governs the topic.
+2. Decide whether the change belongs in `docs/concepts/` or `docs/design/`.
+3. If the change is normative, prefer `docs/design/` and link the relevant ADR.
+4. Update English and Japanese specs in parallel.
+5. Check whether indexes, reading order, or glossary entries need adjustment.
+6. Call out any unresolved design decisions explicitly rather than burying them.
+
+## Review Questions
+
+- does this change weaken compatibility expectations
+- does it make operator-visible behavior less predictable
+- does it blur the meaning of recovery vs replay
+- does it create a hidden cross-platform assumption
+- should there be a new ADR or issue

--- a/.skill/docs-maintainer.md
+++ b/.skill/docs-maintainer.md
@@ -1,0 +1,29 @@
+# ROSC Skill: Docs Maintainer
+
+## Use This Skill When
+
+- the task is documentation-heavy
+- bilingual consistency matters
+- indexes, reading order, links, or repository guidance need updates
+
+## Goal
+
+Leave the documentation clearer, easier to navigate, and safer for later
+implementation work.
+
+## Workflow
+
+1. Identify whether the content belongs in `docs/concepts/` or `docs/design/`.
+2. Update the English and Japanese files together.
+3. Update the nearest relevant index or README.
+4. If AI-entry files rely on the changed rules, update `.agent/.agents` or
+   `.skill/.skills` in the same change.
+5. Keep relative links valid.
+6. Summarize what changed and what should be read next.
+
+## Quality Bar
+
+- terminology stays consistent with the glossary
+- reading order becomes easier, not harder
+- new documents have obvious entry points
+- no English-only or Japanese-only project doc is left behind

--- a/.skill/implementation-planner.md
+++ b/.skill/implementation-planner.md
@@ -1,0 +1,27 @@
+# ROSC Skill: Implementation Planner
+
+## Use This Skill When
+
+- the work is still pre-code
+- design docs need to be translated into milestones or execution slices
+- you need to define what must happen before implementation begins
+
+## Goal
+
+Turn the current specification set into a safe, staged plan for engineering
+work.
+
+## Workflow
+
+1. Start from the approved design docs and ADRs.
+2. Break work into slices that preserve compatibility and rollback safety.
+3. Define acceptance criteria and evidence requirements for each slice.
+4. Separate core requirements from optional accelerators or integrations.
+5. Keep cross-platform expectations explicit.
+6. Recommend the next smallest high-leverage step.
+
+## Avoid
+
+- writing speculative runtime code
+- collapsing planning and implementation into one step
+- mixing long-term stretch goals into the first milestone without boundaries

--- a/.skill/issue-curator.md
+++ b/.skill/issue-curator.md
@@ -1,0 +1,29 @@
+# ROSC Skill: Issue Curator
+
+## Use This Skill When
+
+- a roadmap item needs to become executable backlog work
+- existing issues are too vague for another human or AI to act on
+- milestones, labels, risks, or acceptance criteria need cleanup
+
+## Goal
+
+Make the backlog actionable for contributors who were not part of the original
+discussion.
+
+## Workflow
+
+1. Identify the phase, area, and risk profile.
+2. Write a concrete issue title with searchable nouns.
+3. Include problem statement, desired outcome, design references, acceptance
+   criteria, and validation expectations.
+4. Note compatibility and operator-visible risks.
+5. Link the issue to the relevant milestone and related issues.
+6. Avoid combining unrelated work under one vague ticket.
+
+## Quality Bar
+
+- another contributor can start work without private context
+- acceptance criteria can be checked
+- relevant docs are named directly
+- phase and priority are obvious

--- a/.skills/README.md
+++ b/.skills/README.md
@@ -1,0 +1,31 @@
+# ROSC Skill Catalog
+
+This directory is a compatibility entry point for AI assistants that look for
+project-local skills under `.skill/`.
+
+The repository also ships a mirrored `.skills/` tree because some tools only
+scan plural directory names. Keep the two trees aligned.
+
+## Files
+
+- `SKILL.md`
+  - primary machine-readable skill catalog
+- `SKILLS.md`
+  - compatibility alias for tools that prefer the plural filename
+- `docs-maintainer.md`
+  - for bilingual documentation maintenance and index consistency
+- `design-guardian.md`
+  - for normative design changes, ADR alignment, and scope discipline
+- `issue-curator.md`
+  - for backlog shaping, issue quality, milestones, and acceptance criteria
+- `implementation-planner.md`
+  - for pre-code planning, slicing, and execution sequencing
+- `compatibility-reviewer.md`
+  - for compatibility, recovery, operator impact, and evidence-focused review
+
+## Maintenance Rule
+
+- Update `.skill/` and `.skills/` in the same pull request.
+- Keep file names and content mirrored across both trees.
+- If a skill changes the expected workflow, update the formal docs under
+  `docs/` as well.

--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -1,0 +1,74 @@
+# ROSC Skill Catalog
+
+## Purpose
+
+Use these local skills to keep multi-agent work consistent across planning,
+documentation, backlog management, and future implementation preparation.
+
+## Common Constraints
+
+- preserve OSC 1.0 backward compatibility
+- treat advanced capabilities as additive overlays
+- keep English and Japanese project docs paired
+- keep `.agent/` mirrored with `.agents/`
+- keep `.skill/` mirrored with `.skills/`
+- prefer docs-first changes when semantics or governance change
+- do not claim performance without evidence
+- do not skip issue context, design references, or handoff notes
+
+## Available Skills
+
+### `docs-maintainer.md`
+
+Use when the task is mainly about:
+
+- writing or refining documents
+- keeping English and Japanese files aligned
+- updating indexes, reading order, and cross-links
+- adding new repository guidance without changing runtime behavior
+
+### `design-guardian.md`
+
+Use when the task changes or clarifies:
+
+- normative design behavior
+- compatibility semantics
+- routing, recovery, telemetry, plugin, or security boundaries
+- ADR relationships and design-governance expectations
+
+### `issue-curator.md`
+
+Use when the task is about:
+
+- creating or refining issues
+- ensuring issues are actionable for future contributors or agents
+- aligning backlog items to phases, milestones, risks, and documents
+
+### `implementation-planner.md`
+
+Use when the task is about:
+
+- turning specs into execution slices
+- deciding what should happen before coding
+- defining crate boundaries, acceptance criteria, or validation gates
+- sequencing the first engineering milestones without writing runtime code
+
+### `compatibility-reviewer.md`
+
+Use when the task requires a focused review of:
+
+- OSC compatibility and extension handling
+- operator-visible risk
+- recovery and observability semantics
+- performance claims and evidence quality
+
+## Selection Heuristic
+
+- docs update only: start with `docs-maintainer.md`
+- design meaning changes: start with `design-guardian.md`
+- backlog / GitHub / issue quality: start with `issue-curator.md`
+- roadmap-to-work breakdown: start with `implementation-planner.md`
+- risk review or compatibility check: start with `compatibility-reviewer.md`
+
+If a task spans more than one area, use the most restrictive skill first, then
+bring in the others.

--- a/.skills/SKILLS.md
+++ b/.skills/SKILLS.md
@@ -1,0 +1,74 @@
+# ROSC Skill Catalog
+
+## Purpose
+
+Use these local skills to keep multi-agent work consistent across planning,
+documentation, backlog management, and future implementation preparation.
+
+## Common Constraints
+
+- preserve OSC 1.0 backward compatibility
+- treat advanced capabilities as additive overlays
+- keep English and Japanese project docs paired
+- keep `.agent/` mirrored with `.agents/`
+- keep `.skill/` mirrored with `.skills/`
+- prefer docs-first changes when semantics or governance change
+- do not claim performance without evidence
+- do not skip issue context, design references, or handoff notes
+
+## Available Skills
+
+### `docs-maintainer.md`
+
+Use when the task is mainly about:
+
+- writing or refining documents
+- keeping English and Japanese files aligned
+- updating indexes, reading order, and cross-links
+- adding new repository guidance without changing runtime behavior
+
+### `design-guardian.md`
+
+Use when the task changes or clarifies:
+
+- normative design behavior
+- compatibility semantics
+- routing, recovery, telemetry, plugin, or security boundaries
+- ADR relationships and design-governance expectations
+
+### `issue-curator.md`
+
+Use when the task is about:
+
+- creating or refining issues
+- ensuring issues are actionable for future contributors or agents
+- aligning backlog items to phases, milestones, risks, and documents
+
+### `implementation-planner.md`
+
+Use when the task is about:
+
+- turning specs into execution slices
+- deciding what should happen before coding
+- defining crate boundaries, acceptance criteria, or validation gates
+- sequencing the first engineering milestones without writing runtime code
+
+### `compatibility-reviewer.md`
+
+Use when the task requires a focused review of:
+
+- OSC compatibility and extension handling
+- operator-visible risk
+- recovery and observability semantics
+- performance claims and evidence quality
+
+## Selection Heuristic
+
+- docs update only: start with `docs-maintainer.md`
+- design meaning changes: start with `design-guardian.md`
+- backlog / GitHub / issue quality: start with `issue-curator.md`
+- roadmap-to-work breakdown: start with `implementation-planner.md`
+- risk review or compatibility check: start with `compatibility-reviewer.md`
+
+If a task spans more than one area, use the most restrictive skill first, then
+bring in the others.

--- a/.skills/compatibility-reviewer.md
+++ b/.skills/compatibility-reviewer.md
@@ -1,0 +1,29 @@
+# ROSC Skill: Compatibility Reviewer
+
+## Use This Skill When
+
+- a task could affect OSC interoperability
+- operator-visible behavior or recovery semantics may change
+- a performance claim needs a design-level sanity check
+
+## Goal
+
+Protect backward compatibility, evidence quality, and operational clarity.
+
+## Review Focus
+
+- OSC 1.0 alignment, padding, and big-endian assumptions
+- strict / tolerant / extended mode behavior
+- unknown extension handling
+- recovery cache semantics and late-joiner behavior
+- telemetry meaning and benchmark interpretation
+- rollback and fallback paths
+
+## Output
+
+Leave a concise review that states:
+
+- what looks safe
+- what looks risky
+- what evidence is missing
+- what design doc or issue should be updated next

--- a/.skills/design-guardian.md
+++ b/.skills/design-guardian.md
@@ -1,0 +1,30 @@
+# ROSC Skill: Design Guardian
+
+## Use This Skill When
+
+- a task changes the meaning of a technical rule
+- compatibility semantics, recovery behavior, telemetry semantics, or trust
+  boundaries are being clarified
+- an ADR relationship may need to be referenced or extended
+
+## Goal
+
+Protect the normative design from accidental drift while still improving its
+precision.
+
+## Workflow
+
+1. Find the existing spec or ADR that already governs the topic.
+2. Decide whether the change belongs in `docs/concepts/` or `docs/design/`.
+3. If the change is normative, prefer `docs/design/` and link the relevant ADR.
+4. Update English and Japanese specs in parallel.
+5. Check whether indexes, reading order, or glossary entries need adjustment.
+6. Call out any unresolved design decisions explicitly rather than burying them.
+
+## Review Questions
+
+- does this change weaken compatibility expectations
+- does it make operator-visible behavior less predictable
+- does it blur the meaning of recovery vs replay
+- does it create a hidden cross-platform assumption
+- should there be a new ADR or issue

--- a/.skills/docs-maintainer.md
+++ b/.skills/docs-maintainer.md
@@ -1,0 +1,29 @@
+# ROSC Skill: Docs Maintainer
+
+## Use This Skill When
+
+- the task is documentation-heavy
+- bilingual consistency matters
+- indexes, reading order, links, or repository guidance need updates
+
+## Goal
+
+Leave the documentation clearer, easier to navigate, and safer for later
+implementation work.
+
+## Workflow
+
+1. Identify whether the content belongs in `docs/concepts/` or `docs/design/`.
+2. Update the English and Japanese files together.
+3. Update the nearest relevant index or README.
+4. If AI-entry files rely on the changed rules, update `.agent/.agents` or
+   `.skill/.skills` in the same change.
+5. Keep relative links valid.
+6. Summarize what changed and what should be read next.
+
+## Quality Bar
+
+- terminology stays consistent with the glossary
+- reading order becomes easier, not harder
+- new documents have obvious entry points
+- no English-only or Japanese-only project doc is left behind

--- a/.skills/implementation-planner.md
+++ b/.skills/implementation-planner.md
@@ -1,0 +1,27 @@
+# ROSC Skill: Implementation Planner
+
+## Use This Skill When
+
+- the work is still pre-code
+- design docs need to be translated into milestones or execution slices
+- you need to define what must happen before implementation begins
+
+## Goal
+
+Turn the current specification set into a safe, staged plan for engineering
+work.
+
+## Workflow
+
+1. Start from the approved design docs and ADRs.
+2. Break work into slices that preserve compatibility and rollback safety.
+3. Define acceptance criteria and evidence requirements for each slice.
+4. Separate core requirements from optional accelerators or integrations.
+5. Keep cross-platform expectations explicit.
+6. Recommend the next smallest high-leverage step.
+
+## Avoid
+
+- writing speculative runtime code
+- collapsing planning and implementation into one step
+- mixing long-term stretch goals into the first milestone without boundaries

--- a/.skills/issue-curator.md
+++ b/.skills/issue-curator.md
@@ -1,0 +1,29 @@
+# ROSC Skill: Issue Curator
+
+## Use This Skill When
+
+- a roadmap item needs to become executable backlog work
+- existing issues are too vague for another human or AI to act on
+- milestones, labels, risks, or acceptance criteria need cleanup
+
+## Goal
+
+Make the backlog actionable for contributors who were not part of the original
+discussion.
+
+## Workflow
+
+1. Identify the phase, area, and risk profile.
+2. Write a concrete issue title with searchable nouns.
+3. Include problem statement, desired outcome, design references, acceptance
+   criteria, and validation expectations.
+4. Note compatibility and operator-visible risks.
+5. Link the issue to the relevant milestone and related issues.
+6. Avoid combining unrelated work under one vague ticket.
+
+## Quality Bar
+
+- another contributor can start work without private context
+- acceptance criteria can be checked
+- relevant docs are named directly
+- phase and priority are obvious

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -61,6 +61,16 @@ project-level document は英語版と日本語版をそろえます。
 少なくとも `docs/concepts/` と `docs/design/` 配下の文書を追加・更新するときは、
 英日ペアを維持してください。root の主要文書も、できるだけ英日対応にします。
 
+## AI 協業ファイルのルール
+
+`.agent/`、`.agents/`、`.skill/`、`.skills/` に触れる場合は:
+
+- 互換ミラー側も同じ pull request で更新する
+- `AGENT.md` と `AGENTS.md` の意味をずらさない
+- `SKILL.md` と `SKILLS.md` の意味をずらさない
+- repository policy や workflow の意味が変わるなら、関連する `docs/`
+  側の正式文書も更新する
+
 ## Design Governance Rule
 
 normative な design document の意味を変える PR は、次のどちらかであるべきです。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,16 @@ Project-level documents should exist in both English and Japanese.
 At minimum, when adding or changing documents under `docs/concepts/` or
 `docs/design/`, contributors should preserve the English and Japanese pair.
 
+## AI Collaboration Files
+
+If a change touches `.agent/`, `.agents/`, `.skill/`, or `.skills/`:
+
+- update the mirrored tree in the same pull request
+- keep `AGENT.md` and `AGENTS.md` aligned in meaning
+- keep `SKILL.md` and `SKILLS.md` aligned in meaning
+- update the relevant `docs/` files if repository policy or workflow meaning
+  changed
+
 ## Design Governance Rule
 
 If a PR changes the meaning of a normative design document, it should reference

--- a/README.ja.md
+++ b/README.ja.md
@@ -33,6 +33,15 @@ repository は現在、実装前の準備フェーズにあります。
 - [Design Specs (English)](./docs/design/en/README.md)
 - [Design Specs (Japanese)](./docs/design/ja/README.md)
 
+## AI 協業の入口
+
+- [Agent Brief](./.agent/AGENT.md)
+- [Agent Brief (Plural Alias)](./.agents/AGENTS.md)
+- [Skill Catalog](./.skill/SKILL.md)
+- [Skill Catalog (Plural Alias)](./.skills/SKILLS.md)
+- [AI Collaboration And Agent Interop Plan](./docs/concepts/en/ai-collaboration-and-agent-interop-plan.md)
+- [AI Collaboration And Agent Interop Plan (Japanese)](./docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md)
+
 おすすめの読み順:
 
 1. [Design Reading Order](./docs/design/ja/reading-order.md)
@@ -48,6 +57,7 @@ repository は現在、実装前の準備フェーズにあります。
 - ルーティングコアは決定的で、独立にテスト可能に保つ
 - observability と recovery を後付けではなく最初から重視する
 - プロジェクト文書は英語版と日本語版をそろえる
+- AI の入口ディレクトリはミラーさせ、どのツールでも同じ前提を読むようにする
 
 ## Collaboration Rule
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ What does not exist yet:
 - [Design Specs (English)](./docs/design/en/README.md)
 - [Design Specs (Japanese)](./docs/design/ja/README.md)
 
+## AI Collaboration Entry Points
+
+- [Agent Brief](./.agent/AGENT.md)
+- [Agent Brief (Plural Alias)](./.agents/AGENTS.md)
+- [Skill Catalog](./.skill/SKILL.md)
+- [Skill Catalog (Plural Alias)](./.skills/SKILLS.md)
+- [AI Collaboration And Agent Interop Plan](./docs/concepts/en/ai-collaboration-and-agent-interop-plan.md)
+- [AI Collaboration And Agent Interop Plan (Japanese)](./docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md)
+
 Recommended reading order:
 
 1. [Design Reading Order](./docs/design/ja/reading-order.md)
@@ -50,6 +59,7 @@ Recommended reading order:
 - Keep the routing core deterministic and independently testable.
 - Make observability and recovery first-class, not afterthoughts.
 - Keep all core project documents available in both English and Japanese.
+- Keep AI entry-point trees mirrored so different tools receive the same rules.
 
 ## Collaboration Rules
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -39,10 +39,15 @@
 - GitHub や repository 準備から入る:
   - [GitHub Foundation And Collaboration Plan (English)](./concepts/en/github-foundation-and-collaboration-plan.md)
   - [GitHub Foundation And Collaboration Plan (Japanese)](./concepts/ja/github-foundation-and-collaboration-plan.md)
+  - [AI Collaboration And Agent Interop Plan (English)](./concepts/en/ai-collaboration-and-agent-interop-plan.md)
+  - [AI Collaboration And Agent Interop Plan (Japanese)](./concepts/ja/ai-collaboration-and-agent-interop-plan.md)
   - [License And Contributor Policy (English)](./concepts/en/license-and-contributor-policy.md)
   - [License And Contributor Policy (Japanese)](./concepts/ja/license-and-contributor-policy.md)
   - [CI Expansion And Required-Check Roadmap (English)](./concepts/en/ci-expansion-and-required-check-roadmap.md)
   - [CI Expansion And Required-Check Roadmap (Japanese)](./concepts/ja/ci-expansion-and-required-check-roadmap.md)
+- 複数 AI の入口を確認する:
+  - [Agent Brief](../.agent/AGENT.md)
+  - [Skill Catalog](../.skill/SKILL.md)
 - 技術設計から入る:
   - [Design Reading Order (English)](./design/en/reading-order.md)
   - [Design Reading Order (Japanese)](./design/ja/reading-order.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,10 +40,15 @@ All new project documents should have:
 - For GitHub and repository preparation before coding:
   - [GitHub Foundation And Collaboration Plan (English)](./concepts/en/github-foundation-and-collaboration-plan.md)
   - [GitHub Foundation And Collaboration Plan (Japanese)](./concepts/ja/github-foundation-and-collaboration-plan.md)
+  - [AI Collaboration And Agent Interop Plan (English)](./concepts/en/ai-collaboration-and-agent-interop-plan.md)
+  - [AI Collaboration And Agent Interop Plan (Japanese)](./concepts/ja/ai-collaboration-and-agent-interop-plan.md)
   - [License And Contributor Policy (English)](./concepts/en/license-and-contributor-policy.md)
   - [License And Contributor Policy (Japanese)](./concepts/ja/license-and-contributor-policy.md)
   - [CI Expansion And Required-Check Roadmap (English)](./concepts/en/ci-expansion-and-required-check-roadmap.md)
   - [CI Expansion And Required-Check Roadmap (Japanese)](./concepts/ja/ci-expansion-and-required-check-roadmap.md)
+- For multi-AI repository entry points:
+  - [Agent Brief](../.agent/AGENT.md)
+  - [Skill Catalog](../.skill/SKILL.md)
 - For technical architecture:
   - [Design Reading Order (English)](./design/en/reading-order.md)
   - [Design Reading Order (Japanese)](./design/ja/reading-order.md)

--- a/docs/concepts/en/README.md
+++ b/docs/concepts/en/README.md
@@ -62,6 +62,7 @@ Important interpretation notes:
 - [CI Expansion And Required-Check Roadmap](./ci-expansion-and-required-check-roadmap.md)
 - [GitHub Foundation And Collaboration Plan](./github-foundation-and-collaboration-plan.md)
 - [GitHub Backlog Map](./github-backlog-map.md)
+- [AI Collaboration And Agent Interop Plan](./ai-collaboration-and-agent-interop-plan.md)
 
 ## Related Design Specs
 

--- a/docs/concepts/en/ai-collaboration-and-agent-interop-plan.md
+++ b/docs/concepts/en/ai-collaboration-and-agent-interop-plan.md
@@ -1,0 +1,146 @@
+# AI Collaboration And Agent Interop Plan
+
+## Purpose
+
+This document defines how ROSC should prepare for a repository where multiple
+AI systems may contribute over time.
+
+The goal is not merely to make assistants "work", but to make them converge on
+the same architecture, compatibility promises, review discipline, and handoff
+quality.
+
+## Why This Exists
+
+Different AI tools discover repository context in different ways.
+
+Some look for:
+
+- `.agent/`
+- `.agents/`
+- `.skill/`
+- `.skills/`
+- `AGENT.md`
+- `AGENTS.md`
+- `SKILL.md`
+- `SKILLS.md`
+
+If the repository only supports one discovery convention, future contributors
+can easily miss critical constraints and produce conflicting work. ROSC should
+therefore provide a compatibility layer for agent discovery without letting the
+short AI-facing files become a second, drifting design system.
+
+## Canonical Source Model
+
+The canonical project meaning still lives in `docs/` and the root repository
+policy files.
+
+The AI entry directories exist to:
+
+- shorten onboarding time for new agents
+- expose the must-read rules in one place
+- define handoff and collaboration discipline
+- advertise reusable local skills
+
+They do not replace the formal documentation stack.
+
+## Required AI Entry Trees
+
+ROSC should keep these mirrored directory families:
+
+- `.agent/`
+- `.agents/`
+- `.skill/`
+- `.skills/`
+
+### Agent Trees
+
+The agent trees are for project-wide context and safe workflow expectations.
+
+They should answer:
+
+- what the project is
+- what stage the repository is in
+- what must be read first
+- what must not be broken
+- how work should be handed off
+
+### Skill Trees
+
+The skill trees are for role-specific execution guidance.
+
+They should answer:
+
+- which skill to use for docs work
+- which skill to use for design changes
+- which skill to use for backlog shaping
+- which skill to use for pre-code planning
+- which skill to use for compatibility-focused review
+
+## Mirror Policy
+
+- `.agent/` and `.agents/` should stay textually aligned
+- `.skill/` and `.skills/` should stay textually aligned
+- compatibility alias files such as `AGENT.md` / `AGENTS.md` and
+  `SKILL.md` / `SKILLS.md` should not diverge in meaning
+- when these files change, the related formal docs should be updated if the
+  underlying policy changed
+
+## Recommended Content Shape
+
+The project should maintain both short entry files and supporting files.
+
+### Short Entry Files
+
+These should be optimized for first contact:
+
+- mission
+- project status
+- must-read list
+- non-negotiable rules
+- handoff expectations
+
+### Supporting Files
+
+These should cover:
+
+- repository map
+- workflow and safety rules
+- role-based skill guides
+- handoff template
+
+## Governance Expectations
+
+All AI systems should be steered toward the same governance rules:
+
+- docs-first for architecture and semantics
+- bilingual project documentation
+- pull-request-based review on protected `main`
+- final approval reserved for the repository owner
+- compatibility and rollback discipline before acceleration claims
+
+## Handoff Contract
+
+Every substantial AI contribution should leave a compact handoff that states:
+
+- what changed
+- what documents or issues governed the work
+- what was validated
+- what remains unresolved
+- what the next best step is
+
+This is important because ROSC is intentionally being shaped for
+multi-contributor and multi-agent continuity, not one-off sessions.
+
+## Relationship To The Existing Docs
+
+This plan complements, but does not replace:
+
+- [GitHub Foundation And Collaboration Plan](./github-foundation-and-collaboration-plan.md)
+- [Detailed Delivery Plan](./detailed-delivery-plan.md)
+- [GitHub Backlog Map](./github-backlog-map.md)
+- [Implementation Readiness Checklist](../../design/en/implementation-readiness-checklist.md)
+
+## Non-Negotiable Outcome
+
+The repository should make it easier for different AI systems to produce
+consistent work, not easier for them to bypass design discipline.

--- a/docs/concepts/en/github-foundation-and-collaboration-plan.md
+++ b/docs/concepts/en/github-foundation-and-collaboration-plan.md
@@ -57,8 +57,13 @@ At minimum, the repository should clearly separate:
 - test assets and conformance vectors
 - examples and sample configurations
 - GitHub policy files and templates
+- AI collaboration entry trees
 
 The existing `docs/concepts` and `docs/design` split should be preserved.
+
+The repository should also keep mirrored AI entry trees in `.agent/`,
+`.agents/`, `.skill/`, and `.skills/` so different tools discover the same
+working rules.
 
 ## Required GitHub Baseline Files
 

--- a/docs/concepts/ja/README.md
+++ b/docs/concepts/ja/README.md
@@ -61,6 +61,7 @@ collaboration の準備方針をまとめています。
 - [CI Expansion And Required-Check Roadmap](./ci-expansion-and-required-check-roadmap.md)
 - [GitHub Foundation And Collaboration Plan](./github-foundation-and-collaboration-plan.md)
 - [GitHub Backlog Map](./github-backlog-map.md)
+- [AI 協業と Agent Interop 方針](./ai-collaboration-and-agent-interop-plan.md)
 
 ## 関連する設計仕様
 

--- a/docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md
+++ b/docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md
@@ -1,0 +1,145 @@
+# AI 協業と Agent Interop 方針
+
+## 目的
+
+この文書は、ROSC が将来的に複数の AI システムによって開発されることを前提
+に、repository 側でどのような準備をしておくべきかを定義します。
+
+狙いは単に assistant を「反応させる」ことではなく、複数の AI が同じ
+architecture、compatibility promise、review discipline、handoff quality
+に収束できるようにすることです。
+
+## なぜ必要か
+
+AI ツールごとに、repository から文脈を読む入り口が違います。
+
+たとえば次のような場所を探すものがあります。
+
+- `.agent/`
+- `.agents/`
+- `.skill/`
+- `.skills/`
+- `AGENT.md`
+- `AGENTS.md`
+- `SKILL.md`
+- `SKILLS.md`
+
+ひとつの慣習しか用意しないと、後から参加する AI が重要な制約を読み落とし、
+互いに矛盾する作業をしやすくなります。そこで ROSC では、agent discovery の
+互換レイヤーを用意しつつ、短い AI 向けファイルが正式な設計体系と分離して
+暴走しないようにします。
+
+## 正本の考え方
+
+プロジェクトの正式な意味は、引き続き `docs/` と root の repository policy
+file に置きます。
+
+AI 用の入口ディレクトリは、次の目的で使います。
+
+- 新しい agent の立ち上がり時間を短くする
+- まず読むべき制約を 1 か所にまとめる
+- handoff と協業ルールを明示する
+- 再利用できる local skill を案内する
+
+つまり、正式文書の代替ではなく、正式文書へ正しく到達するための短い入口です。
+
+## 必要な AI 入口ツリー
+
+ROSC では、次の互換ディレクトリ群を維持します。
+
+- `.agent/`
+- `.agents/`
+- `.skill/`
+- `.skills/`
+
+### Agent 系ディレクトリ
+
+agent 系は、project 全体の前提と安全な作業ルールを伝えるために使います。
+
+最低限、次に答えられる必要があります。
+
+- この project は何か
+- repository は今どの段階か
+- 最初に何を読むべきか
+- 何を壊してはいけないか
+- どう handoff するべきか
+
+### Skill 系ディレクトリ
+
+skill 系は、役割別の具体的な作業手順を与えるために使います。
+
+最低限、次に答えられる必要があります。
+
+- docs 作業ではどの skill を使うか
+- 設計変更ではどの skill を使うか
+- issue 整理ではどの skill を使うか
+- 実装前 planning ではどの skill を使うか
+- compatibility review ではどの skill を使うか
+
+## Mirror 方針
+
+- `.agent/` と `.agents/` は意味がずれないように保つ
+- `.skill/` と `.skills/` は意味がずれないように保つ
+- `AGENT.md` / `AGENTS.md`、`SKILL.md` / `SKILLS.md` も意味を分岐させない
+- もしこれらの短い AI 向けファイルの意味を変えるなら、必要に応じて正式文書
+  も同時に更新する
+
+## 推奨する内容構成
+
+短い入口ファイルと補助ファイルの両方を持つのが望ましいです。
+
+### 短い入口ファイル
+
+最初の接触で必要なのは次です。
+
+- mission
+- project status
+- must-read list
+- non-negotiable rule
+- handoff expectation
+
+### 補助ファイル
+
+補助として次を持たせます。
+
+- repository map
+- workflow と safety rule
+- role-based skill guide
+- handoff template
+
+## Governance の期待値
+
+どの AI が来ても、同じ governance に誘導されるべきです。
+
+- architecture や semantics は docs-first
+- プロジェクト文書は英日で用意する
+- protected `main` には pull request review 経由で入れる
+- 最終承認は repository owner が持つ
+- acceleration claim よりも compatibility と rollback discipline を優先する
+
+## Handoff Contract
+
+実質的な AI 作業は、最低限次を含む handoff を残すべきです。
+
+- 何を変えたか
+- どの文書や issue を根拠にしたか
+- 何を検証したか
+- 何が未解決か
+- 次に何をするのが最も良いか
+
+ROSC は単発のやりとりではなく、複数 contributor / 複数 agent が継続的に
+引き継げることを重視しているため、これは重要です。
+
+## 既存文書との関係
+
+この方針は、次の文書を補完するものであって置き換えるものではありません。
+
+- [GitHub Foundation And Collaboration Plan](./github-foundation-and-collaboration-plan.md)
+- [Detailed Delivery Plan](./detailed-delivery-plan.md)
+- [GitHub Backlog Map](./github-backlog-map.md)
+- [Implementation Readiness Checklist](../../design/ja/implementation-readiness-checklist.md)
+
+## 最終的に守りたいこと
+
+この repository では、異なる AI が来ても整合的な作業をしやすくしつつ、設計
+規律を回避しやすくしてはいけません。

--- a/docs/concepts/ja/github-foundation-and-collaboration-plan.md
+++ b/docs/concepts/ja/github-foundation-and-collaboration-plan.md
@@ -55,8 +55,12 @@ cross-platform infrastructure product を目指しています。なので GitHu
 - test asset と conformance vector
 - example と sample configuration
 - GitHub policy file と template
+- AI collaboration entry tree
 
 既存の `docs/concepts` / `docs/design` 分離はそのまま維持します。
+
+加えて、異なるツールが同じ前提を読めるように、`.agent/`、`.agents/`、
+`.skill/`、`.skills/` の mirror も維持します。
 
 ## 先に揃えたい GitHub Baseline File
 


### PR DESCRIPTION
## Summary

- add mirrored `.agent` / `.agents` and `.skill` / `.skills` trees for AI tool compatibility
- add a bilingual concept document describing the AI collaboration and agent interop policy
- wire the new entry points into repository docs and CI checks so the mirror trees stay aligned

## Linked Issues

- Closes #49

## Design Docs Affected

- `docs/concepts/en/ai-collaboration-and-agent-interop-plan.md`
- `docs/concepts/ja/ai-collaboration-and-agent-interop-plan.md`
- `docs/concepts/en/github-foundation-and-collaboration-plan.md`
- `docs/concepts/ja/github-foundation-and-collaboration-plan.md`
- `docs/concepts/en/README.md`
- `docs/concepts/ja/README.md`
- repository-process only change that adds AI collaboration scaffolding and discoverability

## Compatibility Impact

- no OSC wire-format or compatibility-mode behavior changes
- no impact to strict, legacy-tolerant, or extended parsing behavior
- this change only adds repository governance and AI-entry documentation scaffolding

## Evidence

- local docs-quality parity and link checks passed
- local repo-sanity readiness checks passed
- mirrored `.agent` / `.agents` and `.skill` / `.skills` trees are now validated by CI

## Rollback Plan

- revert this PR to remove the AI collaboration entry trees and restore the previous docs/CI state
- fallback is the existing `docs/` and root repository guidance, which remain the canonical source of truth

## Checklist

- [x] I linked the relevant issue(s)
- [x] I updated the relevant design or planning docs
- [x] I considered compatibility impact explicitly
- [x] I included evidence appropriate to the change
- [x] I documented rollback or fallback behavior
- [x] I understand final approval from `@ryo-hasegawa-35` is required before merging to `main`